### PR TITLE
#13: Add nightly release workflow

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,0 +1,57 @@
+name: Nightly Release
+
+on:
+  schedule:
+    # Run at midnight Arizona time (MST, UTC-7) = 07:00 UTC
+    - cron: '0 7 * * *'
+  workflow_dispatch: # Allow manual triggering
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+      
+      - name: Get current date
+        id: date
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+      
+      - name: Get latest tag
+        id: tag
+        run: |
+          if git describe --tags --abbrev=0 2>/dev/null; then
+            echo "tag=$(git describe --tags --abbrev=0)" >> $GITHUB_OUTPUT
+          else
+            echo "tag=" >> $GITHUB_OUTPUT
+          fi
+      
+      - name: Generate release notes
+        id: notes
+        run: |
+          if [ -z "${{ steps.tag.outputs.tag }}" ]; then
+            NOTES="## Nightly Release - ${{ steps.date.outputs.date }}\n\nFirst automated nightly release."
+          else
+            NOTES="## Nightly Release - ${{ steps.date.outputs.date }}\n\n### Changes since ${{ steps.tag.outputs.tag }}\n\n\`\`\`\n$(git log ${{ steps.tag.outputs.tag }}..HEAD --oneline --no-decorate)\n\`\`\`"
+          fi
+          echo "notes<<EOF" >> $GITHUB_OUTPUT
+          echo -e "$NOTES" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+      
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: "nightly-${{ steps.date.outputs.date }}"
+          name: "Nightly Release ${{ steps.date.outputs.date }}"
+          body: ${{ steps.notes.outputs.notes }}
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
Closes #13

## Summary

Adds GitHub Actions workflow to automatically create releases nightly at midnight Arizona time (MST, UTC-7) from whatever is in main.

## Changes

**Created `.github/workflows/nightly-release.yml`:**
- Scheduled to run at 07:00 UTC (midnight MST)
- Creates date-based releases: `nightly-YYYY-MM-DD`
- Generates release notes with changelog since last release
- Includes `workflow_dispatch` for manual triggering

## How It Works

1. **Schedule:** Runs daily at 07:00 UTC (midnight Arizona time)
2. **Versioning:** Date-based tags like `nightly-2025-12-22`
3. **Release Notes:** Auto-generated changelog showing commits since last release
4. **Manual Trigger:** Can be triggered manually via GitHub Actions UI

## Testing

- Workflow syntax validated
- Can be tested manually via `workflow_dispatch` trigger
- First run will create release with "First automated nightly release" message

## Acceptance Criteria

- [x] GitHub Actions workflow file created
- [x] Runs at midnight Arizona time (07:00 UTC)
- [x] Creates release from main branch
- [x] Uses date-based versioning
- [x] Includes release notes/changelog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated daily release workflow has been configured to generate nightly releases with auto-generated release notes. These releases are published automatically and include changelog information based on recent updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->