### PR TITLE
#19: Add standalone CLAUDE.md for Claude Code enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ When you run `agentsdotmd-init` in a repository:
 your-repo/
 ├── AGENTS.md -> ~/.agents_toolkit/AGENTS.md          # Symlink to base constitution
 ├── AGENTS.local.md                                    # Repo-specific overrides (customizable)
-├── CLAUDE.md -> AGENTS.md                             # Claude Code compatibility symlink
+├── CLAUDE.md                                          # Claude Code enforcement (copied, standalone)
 ├── .agents/
 │   └── commands/ -> ~/.agents_toolkit/scripts/        # Universal script location (symlink)
 ├── .cursor/
@@ -115,8 +115,9 @@ your-repo/
 
 ### Symlinks vs Copies
 
-- **Symlinked** (automatic updates): AGENTS.md, `.agents/commands/`, CLAUDE.md
-- **Copied** (customizable per-repo): AGENTS.local.md, `.cursor/commands/*.md`, `.cursor/rules/`, `.github/` templates
+- **Symlinked** (automatic updates): AGENTS.md, `.agents/commands/`
+- **Copied** (refreshed via `--update`): CLAUDE.md, `.cursor/commands/*.md`, `.cursor/rules/`, `.github/` templates
+- **Copied once** (customizable per-repo, never overwritten): AGENTS.local.md
 
 ## Documentation Structure
 
@@ -299,11 +300,11 @@ Safety tiers (per AGENTS.md):
 |-------|------------------|---------------------|---------------|--------|
 | **Cursor** | ✅ Native | ✅ Nearest file wins | Built-in `/commands` (markdown wrappers → `.agents/commands/`) | Fully supported |
 | **GitHub Copilot** | ✅ Native (Aug 2025) | ✅ Nearest file wins | Terminal or tasks (`.agents/commands/`) | Fully supported |
-| **Claude Code** | ⚠️ Uses CLAUDE.md | ✅ Hierarchical | Terminal (`.agents/commands/`), VS Code tasks, aliases | Via CLAUDE.md symlink |
+| **Claude Code** | ✅ Via CLAUDE.md | ✅ Hierarchical | Terminal (`.agents/commands/`), VS Code tasks, aliases | Fully supported |
 | **Jules** | ✅ Native | ✅ Repo root | Terminal (`.agents/commands/`) | Fully supported |
 | **Aider** | ✅ Recommended | ✅ Standard | Terminal (`.agents/commands/`) | Fully supported |
 
-The toolkit creates `CLAUDE.md -> AGENTS.md` symlink for cross-agent compatibility.
+The toolkit creates a standalone `CLAUDE.md` file with explicit workflow enforcement for Claude Code compatibility.
 
 ## Windows Support
 
@@ -346,7 +347,14 @@ python .agents\commands\pr.py
 
 ## VS Code + Claude Code Setup
 
-Claude Code reads `CLAUDE.md -> AGENTS.md` but does not ship Cursor-style `/commands`. Use any of these access methods:
+Claude Code reads `CLAUDE.md` which contains explicit workflow enforcement rules. Unlike a symlink (which Claude Code may not follow correctly), CLAUDE.md is a standalone file with "STOP" language at the top.
+
+**Why standalone instead of symlink?**
+- Claude Code sometimes ignores symlinked content
+- Explicit "STOP" rules at the top of CLAUDE.md are more effective
+- AGENTS.local.md also contains workflow enforcement as a backup
+
+**Running workflow scripts:**
 
 1. **Direct terminal:** `python3 .agents/commands/status.py` (or `python` on Windows)
 2. **VS Code tasks:** Cmd+Shift+P → "Tasks: Run Task" → "Agents: Status" (optional `.vscode/tasks.json` installed by `agentsdotmd-init` when you opt in)

--- a/bin/agentsdotmd-init
+++ b/bin/agentsdotmd-init
@@ -85,14 +85,41 @@ else
     echo -e "${GREEN}✓ Already exists${NC}"
 fi
 
-# 3. Symlink CLAUDE.md for Claude Code compatibility
+# 3. Copy CLAUDE.md for Claude Code enforcement
 echo ""
-echo -e "${YELLOW}[3/9] Symlinking CLAUDE.md (Claude Code compat)...${NC}"
-if [ ! -e "$TARGET_DIR/CLAUDE.md" ]; then
-    ln -s AGENTS.md "$TARGET_DIR/CLAUDE.md"
-    echo -e "${GREEN}✓ Created CLAUDE.md -> AGENTS.md${NC}"
+echo -e "${YELLOW}[3/9] Installing CLAUDE.md (Claude Code enforcement)...${NC}"
+if [ "$UPDATE_MODE" = true ]; then
+    if [ -f "$TARGET_DIR/CLAUDE.md" ]; then
+        read -p "Update existing CLAUDE.md? (y/N): " -n 1 -r
+        echo
+        if [[ $REPLY =~ ^[Yy]$ ]]; then
+            # Remove symlink if it exists, then copy
+            [ -L "$TARGET_DIR/CLAUDE.md" ] && rm "$TARGET_DIR/CLAUDE.md"
+            cp "$TOOLKIT_DIR/templates/CLAUDE.md" "$TARGET_DIR/CLAUDE.md"
+            echo -e "${GREEN}✓ Updated CLAUDE.md${NC}"
+        else
+            echo -e "${YELLOW}⊘ Skipped CLAUDE.md${NC}"
+        fi
+    else
+        cp "$TOOLKIT_DIR/templates/CLAUDE.md" "$TARGET_DIR/CLAUDE.md"
+        echo -e "${GREEN}✓ Created CLAUDE.md${NC}"
+    fi
+elif [ -f "$TARGET_DIR/CLAUDE.md" ] && [ ! -L "$TARGET_DIR/CLAUDE.md" ]; then
+    echo -e "${GREEN}✓ Already exists (standalone file)${NC}"
+elif [ -L "$TARGET_DIR/CLAUDE.md" ]; then
+    echo -e "${YELLOW}⚠️  CLAUDE.md is a symlink (old format)${NC}"
+    read -p "Replace with standalone file? (Y/n): " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Nn]$ ]]; then
+        rm "$TARGET_DIR/CLAUDE.md"
+        cp "$TOOLKIT_DIR/templates/CLAUDE.md" "$TARGET_DIR/CLAUDE.md"
+        echo -e "${GREEN}✓ Replaced symlink with standalone CLAUDE.md${NC}"
+    else
+        echo -e "${YELLOW}⊘ Kept symlink${NC}"
+    fi
 else
-    echo -e "${GREEN}✓ Already exists${NC}"
+    cp "$TOOLKIT_DIR/templates/CLAUDE.md" "$TARGET_DIR/CLAUDE.md"
+    echo -e "${GREEN}✓ Created CLAUDE.md${NC}"
 fi
 
 # 4. Symlink .agents/commands/ (agent-agnostic scripts)
@@ -267,7 +294,7 @@ echo -e "${GREEN}================================================${NC}"
 echo ""
 echo -e "${BLUE}Files managed:${NC}"
 echo "  • AGENTS.md (symlink to global constitution; auto-updates via toolkit)"
-echo "  • CLAUDE.md (symlink for Claude Code)"
+echo "  • CLAUDE.md (copied; Claude Code enforcement; refreshed via --update)"
 echo "  • .agents/commands/ (symlink to toolkit scripts; agent-agnostic)"
 echo "  • .cursor/commands/*.md (Cursor prompt wrappers for slash commands)"
 echo "  • .cursor/rules/agents-workflow/RULE.md (copied; refreshed via --update)"

--- a/templates/AGENTS.local.md.example
+++ b/templates/AGENTS.local.md.example
@@ -4,6 +4,22 @@ This file extends the base AGENTS.md constitution with project-specific customiz
 
 **Precedence:** AGENTS.local.md overrides AGENTS.md when conflicts exist.
 
+---
+
+## ⛔ Workflow Enforcement (DO NOT SKIP)
+
+**Before implementing ANY code changes, you MUST:**
+
+1. ✅ Verify a GitHub issue exists for this work (or create one first)
+2. ✅ Confirm you are on a feature branch, NOT main/master: `git branch --show-current`
+3. ✅ Create a draft PR linking to the issue
+
+**If on main/master:** STOP and create a feature branch before making any file changes.
+
+See **AGENTS.md** for complete workflow rules. See **CLAUDE.md** for Claude Code-specific enforcement.
+
+---
+
 **What Goes Here:** Project-specific details like tech stack, build commands, testing requirements, and architectural patterns. Keep the base AGENTS.md focused on universal workflow standards; put project-specific context here.
 
 **Common Extension Areas:**

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -1,0 +1,53 @@
+# CLAUDE.md — Claude Code Workflow Rules
+
+## ⛔ STOP — READ BEFORE ANY ACTION
+
+**YOU MUST follow these rules for ALL code changes:**
+
+1. **NEVER write code without a GitHub issue first.** Create the issue, get user approval, THEN implement.
+2. **NEVER commit to main/master.** Create a feature branch: `{type}/{issue-num}-{desc}`
+3. **ALWAYS create a draft PR immediately** after creating the branch and linking it to the issue.
+4. **ALWAYS end implementation rounds** with clickable links to all GitHub artifacts created.
+
+**If the user asks you to write code or make changes:**
+- STOP and ask: "Should I create a GitHub issue first, or is there an existing issue for this work?"
+- Verify you are NOT on main/master before making any file changes
+- Create feature branch before any edits
+
+---
+
+## Quick Reference
+
+| Action | Command |
+|--------|---------|
+| Create issue | `gh issue create --title "..." --body "..."` |
+| Create branch | `git checkout -b {type}/{issue-num}-{desc}` |
+| Create draft PR | `gh pr create --draft --title "[WIP] #{num}: {desc}" --body "Closes #{num}"` |
+| Check branch | `git branch --show-current` |
+
+**Branch types:** `fix/`, `feat/`, `refactor/`, `docs/`, `chore/`
+
+---
+
+## Full Workflow Details
+
+For complete workflow rules, see **AGENTS.md** in this repository. Key sections:
+
+- **Prime Directives** — Non-negotiable rules
+- **Issue-First Development** — Issue template and approval process
+- **Branch Management** — Naming conventions and rules
+- **Pull Request Protocol** — PR requirements
+- **GitHub Output Requirements** — Clickable links and end-of-round summaries
+
+---
+
+## Why This Matters
+
+This workflow ensures:
+- ✅ All work is traceable to issues
+- ✅ Code review happens via PRs
+- ✅ No direct commits to main/master
+- ✅ Clear documentation trail
+
+**The issue is the contract. The PR is the delivery. Documentation is the proof.**
+

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -26,7 +26,7 @@ echo "  • .cursor/rules/agents-workflow/"
 echo "  • .cursor/commands/*.md"
 echo "  • .issue_screenshots/ (if empty)"
 echo ""
-echo -e "${RED}AGENTS.md, .github/ templates will NOT be removed${NC}"
+echo -e "${RED}AGENTS.md, CLAUDE.md, .github/ templates will NOT be removed${NC}"
 echo ""
 
 read -p "Continue? (y/N): " -n 1 -r
@@ -76,7 +76,7 @@ fi
 echo ""
 echo -e "${GREEN}Uninstallation complete${NC}"
 echo ""
-echo -e "${YELLOW}Note: AGENTS.md and .github/ templates were not removed${NC}"
+echo -e "${YELLOW}Note: AGENTS.md, CLAUDE.md, and .github/ templates were not removed${NC}"
 echo "Remove them manually if needed"
 echo ""
 


### PR DESCRIPTION
## Summary

Claude Code was ignoring the CLAUDE.md -> AGENTS.md symlink chain and proceeding to implement code directly on main without creating issues or feature branches. This PR changes CLAUDE.md from a symlink to a standalone file with explicit "STOP" enforcement at the top.

## Changes

- **New `templates/CLAUDE.md`** - Standalone file with:
  - Explicit "STOP — READ BEFORE ANY ACTION" section
  - Quick reference table for common commands
  - Reference to AGENTS.md for full workflow details

- **Updated `templates/AGENTS.local.md.example`** - Added workflow enforcement section at the top that Claude Code will definitely read

- **Updated `bin/agentsdotmd-init`** - Changed from symlinking CLAUDE.md to copying it:
  - Prompts to update CLAUDE.md in `--update` mode
  - Detects and offers to replace old symlinks with standalone file

- **Updated `README.md`**:
  - Updated file tree showing CLAUDE.md as copied file
  - Updated "Symlinks vs Copies" section
  - Updated Cross-Agent Compatibility table
  - Expanded VS Code + Claude Code Setup section with rationale

- **Updated `uninstall.sh`** - Messaging now mentions CLAUDE.md is not removed

## How to Test

1. Run `agentsdotmd-init` in a test repo
2. Verify CLAUDE.md is a regular file (not symlink)
3. Check CLAUDE.md content has "STOP" section at top
4. Run `agentsdotmd-init --update` to verify update prompts work
5. Test with Claude Code to verify it respects the workflow rules

Closes #19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Claude Code setup documentation for VS Code integration with guidance on script execution and shell aliases
  * Added workflow enforcement guidelines covering issue verification, branch management, and pull request requirements
  * Improved Windows setup instructions with expanded fallback support options

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->