### PR TITLE
[WIP] #22: Fix nightly tag collision on multiple daily runs

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -66,8 +66,8 @@ jobs:
         if: steps.changes.outputs.has_changes == 'true'
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: "nightly-${{ steps.date.outputs.date }}"
-          name: "Nightly Release ${{ steps.date.outputs.date }}"
+          tag_name: "nightly-${{ steps.date.outputs.date }}-${{ github.run_number }}"
+          name: "Nightly Release ${{ steps.date.outputs.date }}-${{ github.run_number }}"
           body: ${{ steps.notes.outputs.notes }}
           draft: false
           prerelease: false


### PR DESCRIPTION
## Summary
Fixes nightly workflow tag collision when manually triggered multiple times per day by appending `github.run_number` to tag names.

## Changes
- Modified `.github/workflows/nightly-release.yml` (lines 69-70)
  - **Before**: `tag_name: "nightly-YYYY-MM-DD"`
  - **After**: `tag_name: "nightly-YYYY-MM-DD-N"` where N is the run number
- Updated release name to match new tag format

## Why This Works
- `github.run_number` is a globally incrementing counter that never resets
- Each workflow run (automatic or manual) gets a unique number
- No more tag reuse → artifacts always match the commit in the changelog
- Existing releases (like `nightly-2025-12-22`) remain unchanged
- All releases preserved as audit trail

## Testing Notes
⚠️ **Cannot fully test until merged** - `workflow_dispatch` only triggers on the default branch (main). After merge, validation requires:
1. Manual trigger via Actions → Nightly Release → Run workflow
2. Verify new tag format: `nightly-YYYY-MM-DD-{run_number}`
3. Verify artifacts match HEAD commit at time of run

## Acceptance Criteria
- [x] Tag format changed to include run number
- [x] Release name matches tag format
- [ ] Post-merge validation: Multiple manual runs create distinct tags
- [ ] Post-merge validation: Artifacts match changelog commits

Closes #22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated nightly release versioning to include build run identifier for unique release tracking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->