### PR TITLE
[WIP] #24: Update promote-to-stable for new nightly tag format

### DIFF
--- a/.github/workflows/promote-to-stable.yml
+++ b/.github/workflows/promote-to-stable.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       nightly_tag:
-        description: 'Nightly tag to promote (e.g., nightly-2025-12-22)'
+        description: 'Nightly tag to promote (e.g., nightly-2025-12-22-12345)'
         required: true
         type: string
 
@@ -23,9 +23,9 @@ jobs:
       
       - name: Validate nightly tag format
         run: |
-          if [[ ! "${{ inputs.nightly_tag }}" =~ ^nightly-[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+          if [[ ! "${{ inputs.nightly_tag }}" =~ ^nightly-[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]+$ ]]; then
             echo "❌ Error: Invalid tag format"
-            echo "Expected: nightly-YYYY-MM-DD"
+            echo "Expected: nightly-YYYY-MM-DD-N (where N is run number)"
             echo "Got: ${{ inputs.nightly_tag }}"
             exit 1
           fi
@@ -34,7 +34,9 @@ jobs:
         id: tags
         run: |
           NIGHTLY="${{ inputs.nightly_tag }}"
+          # Strip 'nightly-' prefix and '-N' suffix to get YYYY-MM-DD
           DATE="${NIGHTLY#nightly-}"
+          DATE="${DATE%-*}"
           STABLE="stable-${DATE}"
           echo "date=${DATE}" >> $GITHUB_OUTPUT
           echo "stable=${STABLE}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
Updates the `promote-to-stable.yml` workflow to accept the new nightly tag format with run numbers introduced in #22.

## Changes
Modified `.github/workflows/promote-to-stable.yml`:

1. **Regex validation** (line 26): `^nightly-[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]+$`
   - Now accepts run number suffix: `nightly-2025-12-23-4`
   
2. **Date extraction** (lines 38-39): Strip run number
   ```bash
   DATE="${NIGHTLY#nightly-}"  # Remove prefix
   DATE="${DATE%-*}"           # Remove -N suffix
   ```
   - `nightly-2025-12-23-4` → `stable-2025-12-23`

3. **Updated description** (line 7): Example shows new format with run number

## Why These Changes
After #22 merged, nightly releases use format `nightly-YYYY-MM-DD-N`. The promote workflow was rejecting these tags with:
```
❌ Error: Invalid tag format
Expected: nightly-YYYY-MM-DD
Got: nightly-2025-12-23-4
```

## Testing Notes
⚠️ **Cannot fully test until merged** - workflow is on default branch only. Post-merge validation:
1. Trigger a nightly release to get a tag like `nightly-2025-12-23-N`
2. Run Actions → Promote Nightly to Stable with that tag
3. Verify stable release created as `stable-2025-12-23` (date only, no run number)

## Example
**Input**: `nightly-2025-12-23-20447208819`  
**Output**: `stable-2025-12-23`

Closes #24

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to support an extended nightly tag format with run number identification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->