### PR TITLE
[WIP] #26: Fix shell syntax error in promote-to-stable workflow

### DIFF
--- a/.github/workflows/promote-to-stable.yml
+++ b/.github/workflows/promote-to-stable.yml
@@ -74,16 +74,18 @@ jobs:
       
       - name: Create stable release
         run: |
-          NOTES="## Stable Release - ${{ steps.tags.outputs.date }}
+          cat > /tmp/stable-release-notes.md <<RELEASE_NOTES_EOF
+          ## Stable Release - ${{ steps.tags.outputs.date }}
 
           🎉 Promoted from \`${{ inputs.nightly_tag }}\` to stable
 
           ### Original Release Notes
-          ${{ steps.nightly.outputs.body }}"
+          ${{ steps.nightly.outputs.body }}
+          RELEASE_NOTES_EOF
 
           gh release create "${{ steps.tags.outputs.stable }}" \
             --title "Stable Release ${{ steps.tags.outputs.date }}" \
-            --notes "${NOTES}" \
+            --notes-file /tmp/stable-release-notes.md \
             --target "${{ steps.nightly.outputs.commit }}" \
             --latest
         env:


### PR DESCRIPTION
## Summary
Fixes shell syntax errors in the `promote-to-stable.yml` workflow when nightly release bodies contain special characters like parentheses, backticks, or other shell metacharacters.

## Problem
The workflow was constructing release notes using a double-quoted string with direct interpolation:
```bash
NOTES="... ${{ steps.nightly.outputs.body }}"
```

When the body contained special characters (e.g., `(#21)` in commit messages), the shell tried to interpret them, causing errors like:
```
command not found: 199e4ca
syntax error near unexpected token `('
```

## Solution
Changed to use a heredoc that writes to a temporary file, then passes it to `gh release create` with `--notes-file`:

```bash
cat > /tmp/stable-release-notes.md <<RELEASE_NOTES_EOF
...
${{ steps.nightly.outputs.body }}
RELEASE_NOTES_EOF

gh release create ... --notes-file /tmp/stable-release-notes.md
```

## Why This Works
- Heredoc prevents shell interpretation of special characters in the body content
- GitHub Actions variables still expand correctly (heredoc delimiter not quoted)
- `--notes-file` avoids any quoting/escaping issues with the notes content
- All special characters (parentheses, backticks, etc.) are preserved literally

## Testing Notes
⚠️ **Cannot fully test until merged** - workflow only runs on default branch. Post-merge validation:
1. Promote a nightly release that contains commit messages with parentheses
2. Verify stable release is created successfully
3. Verify release notes preserve all content correctly

Closes #26