### PR TITLE
#26: Additional fix for promote-to-stable shell interpretation

### DIFF
--- a/.github/workflows/promote-to-stable.yml
+++ b/.github/workflows/promote-to-stable.yml
@@ -74,14 +74,17 @@ jobs:
       
       - name: Create stable release
         run: |
-          cat > /tmp/stable-release-notes.md <<RELEASE_NOTES_EOF
-          ## Stable Release - ${{ steps.tags.outputs.date }}
-
-          🎉 Promoted from \`${{ inputs.nightly_tag }}\` to stable
-
-          ### Original Release Notes
-          ${{ steps.nightly.outputs.body }}
-          RELEASE_NOTES_EOF
+          # Get nightly body safely using gh CLI
+          gh release view "${{ inputs.nightly_tag }}" --json body -q .body > /tmp/nightly-body.txt
+          
+          {
+            echo "## Stable Release - ${{ steps.tags.outputs.date }}"
+            echo ""
+            echo "🎉 Promoted from \`${{ inputs.nightly_tag }}\` to stable"
+            echo ""
+            echo "### Original Release Notes"
+            cat /tmp/nightly-body.txt
+          } > /tmp/stable-release-notes.md
 
           gh release create "${{ steps.tags.outputs.stable }}" \
             --title "Stable Release ${{ steps.tags.outputs.date }}" \
@@ -93,12 +96,17 @@ jobs:
       
       - name: Mark nightly as superseded
         run: |
-          UPDATED_BODY="> ⚠️ **Superseded by \`${{ steps.tags.outputs.stable }}\`**
-
-          ${{ steps.nightly.outputs.body }}"
+          # Get nightly body safely using gh CLI (reuse from previous step or fetch again)
+          gh release view "${{ inputs.nightly_tag }}" --json body -q .body > /tmp/nightly-body.txt
+          
+          {
+            echo "> ⚠️ **Superseded by \`${{ steps.tags.outputs.stable }}\`**"
+            echo ""
+            cat /tmp/nightly-body.txt
+          } > /tmp/nightly-superseded-notes.md
 
           gh release edit "${{ inputs.nightly_tag }}" \
-            --notes "${UPDATED_BODY}" \
+            --notes-file /tmp/nightly-superseded-notes.md \
             --prerelease \
             --latest=false
         env:


### PR DESCRIPTION
## Summary
Additional fix for #26 - uses `gh release view` to safely retrieve body content instead of heredoc interpolation, preventing shell interpretation of special characters.

## Problem
Even with heredoc, when GitHub Actions expands `${{ steps.nightly.outputs.body }}`, the shell still tries to interpret special characters (backticks, parentheses) in the expanded content, causing errors in both:
- "Create stable release" step (body was incomplete)
- "Mark nightly as superseded" step (failed completely)

## Solution
- Use `gh release view --json body -q .body` to safely retrieve the body content
- Write release notes using `echo`/`cat` instead of heredoc variable interpolation
- This completely avoids shell interpretation of the body content

## Testing
The workflow was partially successful - stable release was created but with incomplete body. This fix ensures both steps complete successfully.

Closes #26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release contains internal infrastructure improvements with no end-user visible changes. Updates were made to optimize release automation processes.

* **Chores**
  * Refactored internal release automation workflow for improved efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->