### PR TITLE
[WIP] #57: Add /walkthrough command and walkthrough documentation mandate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ Non-negotiable rules for all AI agents. Violations constitute workflow failures.
 5. **ALWAYS document work in GitHub issues and PRs—not just chat.**
 6. **ALWAYS provide clickable markdown hyperlinks for GitHub resources.**
 7. **ALWAYS end implementation rounds with clickable links to all artifacts** (issues, PRs, commits, branches).
+8. **ALWAYS produce a walkthrough document after each substantial implementation round.** Walkthroughs go in `docs/walkthroughs/{issue}_W{N}.md` (W1, W2, ...).
 
 ---
 
@@ -86,6 +87,33 @@ See [PR Template](docs/AGENTS_REFERENCE.md#pr-template).
 
 Document each feedback round in issue comments: what was wrong, what changed, insights gained.  
 Document failed approaches before trying alternatives.
+
+---
+
+## Walkthrough Documentation
+
+**After each substantial implementation round**, create a walkthrough document:
+
+**Location:** `docs/walkthroughs/{issue}_W{N}.md`
+- `{issue}` = GitHub issue number
+- `{N}` = Sequential number for the issue (W1, W2, W3...)
+
+**Required Sections:**
+1. Summary (what was implemented)
+2. Files Changed (table of modifications)
+3. Implementation Details (technical decisions)
+4. How to Verify (testing steps)
+5. Known Limitations (caveats)
+6. Commits (links to relevant commits)
+
+**When to produce:**
+- After completing each implementation round
+- Before marking PR ready for review
+- When user requests via `/walkthrough` command
+
+**Retention:** When an issue is closed, prompt the user whether to keep or archive/remove the walkthrough files.
+
+See [Walkthrough Template](docs/AGENTS_REFERENCE.md#walkthrough-template) for full format.
 
 ---
 

--- a/commands/src/walkthrough.md
+++ b/commands/src/walkthrough.md
@@ -1,0 +1,56 @@
+Create or update a walkthrough document for the current implementation round.
+
+**Purpose:**
+Document what was implemented so far to ensure knowledge transfer, auditability, and alignment with [Walkthrough Documentation](../../AGENTS.md#walkthrough-documentation).
+
+**Location:** `docs/walkthroughs/{issue}_W{N}.md`
+- `{issue}` = GitHub issue number (e.g., `57`)
+- `{N}` = Sequential walkthrough number for that issue (W1, W2, W3…)
+
+**Walkthrough Template:**
+# Walkthrough: #{issue} - W{N}
+
+**Issue:** [#{issue}: Title](link)
+**Branch:** `{branch-name}`
+**Date:** YYYY-MM-DD
+
+## Summary
+[1-2 sentences: what was implemented in this round]
+
+## Files Changed
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `path/to/file` | Created/Modified/Deleted | Brief description |
+
+## Implementation Details
+[Key technical decisions, patterns used, rationale]
+
+## How to Verify
+1. [Step to test the changes]
+2. [Expected result]
+
+## Known Limitations
+- [Any caveats or edge cases not handled]
+
+## Next Steps
+- [ ] [Remaining work for this issue, if any]
+
+## Commits
+- [`abc1234`: Message](commit-link)
+
+**Workflow:**
+1. Detect the current issue number from branch name (per AGENTS.md branch rules).
+2. Ensure `docs/walkthroughs/` exists (create if missing).
+3. Count existing walkthroughs for this issue (`{issue}_W*.md`) to determine the next `{N}` (starting at 1).
+4. Create `docs/walkthroughs/{issue}_W{N}.md` with the template above and populate details for this implementation round.
+5. Commit and push the walkthrough alongside the code changes for this round.
+
+**When to Create:**
+- After each substantial implementation round (MANDATORY per AGENTS.md).
+- When the user invokes `/walkthrough`.
+- Before marking a PR ready for review.
+
+**Retention on Issue Close:**
+- When the issue is closed, prompt the user whether to keep or archive/remove the walkthroughs for that issue.
+
+

--- a/docs/AGENTS_REFERENCE.md
+++ b/docs/AGENTS_REFERENCE.md
@@ -154,6 +154,46 @@ Closes #{issue-num}
 
 ---
 
+## Walkthrough Template
+
+Use this for `docs/walkthroughs/{issue}_W{N}.md` (N = W1, W2, W3... for that issue).
+
+```markdown
+# Walkthrough: #{issue} - W{N}
+
+**Issue:** [#{issue}: Title](link)
+**Branch:** `{branch-name}`
+**Date:** YYYY-MM-DD
+
+## Summary
+[1-2 sentences: what was implemented in this round]
+
+## Files Changed
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `path/to/file` | Created/Modified/Deleted | Brief description |
+
+## Implementation Details
+[Key technical decisions, patterns used, rationale]
+
+## How to Verify
+1. [Step to test the changes]
+2. [Expected result]
+
+## Known Limitations
+- [Any caveats or edge cases not handled]
+
+## Next Steps
+- [ ] [Remaining work for this issue, if any]
+
+## Commits
+- [`abc1234`: Message](commit-link)
+```
+
+**Retention:** When an issue is closed, prompt whether to keep or archive/remove the walkthroughs.
+
+---
+
 ## GitHub Output Examples
 
 ### Good End-of-Round Summary


### PR DESCRIPTION
Closes #57

## Summary
Added new `/walkthrough` command and integrated walkthrough documentation as a mandatory workflow practice in AGENTS.md.

## Changes
- Created `commands/src/walkthrough.md` with full command specification
- Added Prime Directive #8 to AGENTS.md requiring walkthroughs after each implementation round
- Added Walkthrough Documentation section to AGENTS.md
- Added Walkthrough Template section to docs/AGENTS_REFERENCE.md
- Rebuilt agent commands via build_commands.py install

## How to Test
1. Run `python3 bin/build_commands.py install` to verify commands rebuild
2. Check that `/walkthrough` command appears in `~/.cursor/commands/`
3. Verify AGENTS.md includes new Prime Directive #8 and Walkthrough Documentation section